### PR TITLE
Fixing mathjax overflow on smaller devices

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -238,7 +238,7 @@ mjx-container {
 }
 
 mjx-container > svg {
-    max-width: 100%;
+    max-width: calc(100% - 1ch);
 }
 
 mjx-assistive-mml {


### PR DESCRIPTION
This PR addresses an issue where MathJax-rendered SVG content overflows the container on smaller devices. This fix ensures proper scaling and improves usability across mobile and small screens.

#### **Changes**  
- Add `max-width: 100%` to `mjx-container > svg` to prevent overflow.

#### **Reason for Fix**  
On smaller devices, MathJax content was not respecting container boundaries, leading to layout-breaking overflows.

---

### **Testing**  
1. Render MathJax content on both small and large screens.  
2. Confirm that the content scales appropriately within the container.  
3. Ensure no unintended regressions appear on larger devices.

---

### **Screenshots**  
**Before Fix**: Content overflows the screen on mobile devices.  
![CleanShot 2024-12-18 at 13 02 46@2x](https://github.com/user-attachments/assets/ac4c097a-a0a3-4f29-a6ad-12eabe7736c6)

**After Fix**: Content properly scales within container boundaries.
![CleanShot 2024-12-18 at 13 03 04@2x](https://github.com/user-attachments/assets/73e413ec-f48b-42ca-886e-ed6b4346591b)

